### PR TITLE
Fix BoxDestroyer's and FlashMob's configs

### DIFF
--- a/BoxDestroyer/Scripts/config.lua
+++ b/BoxDestroyer/Scripts/config.lua
@@ -1,12 +1,11 @@
 local config = {
     --@description Modifier keys that need to be pressed with the key set below
+    --@type list[ModifierKey]
+    --@default { ModifierKey.CONTROL }
+    modifier_keys = { ModifierKey.CONTROL },
+    --@description Key to delete all empty boxes
     --@type Key
     --@default Key.F7
-    modifier_keys = { ModifierKey.CONTROL },
-
-    --@description Key to delete all empty boxes
-	--@type Key
-	--@default Key.F7
     key = Key.F7
 }
 return config

--- a/FlashMob/Scripts/config.lua
+++ b/FlashMob/Scripts/config.lua
@@ -3,15 +3,13 @@ local config = {
     --@type int
     --@default 50
     max_customer_amount = 50,
-
     --@description Modifier keys that need to be pressed with the key set below
-    --@type Key
-    --@default Key.F7
+    --@type list[ModifierKey]
+    --@default { ModifierKey.CONTROL }
     modifier_keys = { ModifierKey.CONTROL },
-
     --@description Key to delete all empty boxes
-	--@type Key
-	--@default Key.F4
+    --@type Key
+    --@default Key.F4
     key = Key.F4
 }
 return config


### PR DESCRIPTION
This pull request fixes BoxDestroyer's and FlashMob's configs by changing the type declaration from `Key` to `list[ModifierKey]`.
Also updated the default declaration to be a valid modifier_keys value.

Also, consider changing the type of `max_acceptable_cost_multiplier` in your RichCustomers mod to `float`, OverpricedRatio accepts a double, which allows for some more configurability:
https://github.com/Doug-Murphy/GroceryStoreSimulatorMods/blob/main/RichCustomers/Scripts/config.lua#L4